### PR TITLE
feat(prelude) Add `Some` and `None` in a prelude

### DIFF
--- a/Option.php
+++ b/Option.php
@@ -75,7 +75,7 @@ class Option
      * equivalent.
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
+     * $x = Hoa\Option\Some(42);
      * $y = Hoa\Option\Some(42);
      *
      * assert($x->isSome());
@@ -95,7 +95,7 @@ class Option
      * In this example, `Option::none()` and `None()` are strictly equivalent.
      *
      * ```php
-     * $x = Hoa\Option\Option::none();
+     * $x = Hoa\Option\None();
      * $y = Hoa\Option\None();
      *
      * assert($x->isNone());
@@ -113,8 +113,8 @@ class Option
      * # Examples
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
-     * $y = Hoa\Option\Option::none();
+     * $x = Hoa\Option\Some(42);
+     * $y = Hoa\Option\None();
      *
      * assert(true  === $x->isSome());
      * assert(false === $y->isSome());
@@ -131,8 +131,8 @@ class Option
      * # Examples
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
-     * $y = Hoa\Option\Option::none();
+     * $x = Hoa\Option\Some(42);
+     * $y = Hoa\Option\None();
      *
      * assert(false === $x->isNone());
      * assert(true  === $y->isNone());
@@ -154,7 +154,7 @@ class Option
      * There is some value (`42`), so `expect` unwraps successfully:
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
+     * $x = Hoa\Option\Some(42);
      *
      * assert($x->expect('damn!') === 42);
      * ```
@@ -162,7 +162,7 @@ class Option
      * There is no value, so a `RuntimeException` is thrown:
      *
      * ```php,must_throw(RuntimeException)
-     * $x = Hoa\Option\Option::none();
+     * $x = Hoa\Option\None();
      *
      * assert($x->expect('damn!') === 42);
      * ```
@@ -192,7 +192,7 @@ class Option
      * There is some value (`42`), so `unwrap` is successful:
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
+     * $x = Hoa\Option\Some(42);
      *
      * assert($x->unwrap() === 42);
      * ```
@@ -200,7 +200,7 @@ class Option
      * There is no value, so a `RuntimeException` is thrown:
      *
      * ```php,must_throw(RuntimeException)
-     * $x = Hoa\Option\Option::none();
+     * $x = Hoa\Option\None();
      *
      * assert($x->unwrap() === 42);
      * ```
@@ -217,8 +217,8 @@ class Option
      * # Examples
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
-     * $y = Hoa\Option\Option::none();
+     * $x = Hoa\Option\Some(42);
+     * $y = Hoa\Option\None();
      *
      * assert($x->unwrapOr(153) === 42);
      * assert($y->unwrapOr(153) === 153);
@@ -240,8 +240,8 @@ class Option
      * # Examples
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
-     * $y = Hoa\Option\Option::none();
+     * $x = Hoa\Option\Some(42);
+     * $y = Hoa\Option\None();
      *
      * $else = function () { return 153; };
      *
@@ -265,7 +265,7 @@ class Option
      * # Examples
      *
      * ```php
-     * $maybeMessage       = Hoa\Option\Option::some('Hello, World!');
+     * $maybeMessage       = Hoa\Option\Some('Hello, World!');
      * $maybeMessageLength = $maybeMessage->map(
      *     function (string $message): int {
      *         return strlen($message);
@@ -291,8 +291,8 @@ class Option
      * # Examples
      *
      * ```php
-     * $x = Hoa\Option\Option::some('Hello, World!');
-     * $y = Hoa\Option\Option::none();
+     * $x = Hoa\Option\Some('Hello, World!');
+     * $y = Hoa\Option\None();
      *
      * assert($x->mapOr('strlen', 42)->unwrap() === 13);
      * assert($y->mapOr('strlen', 42)->unwrap() === 42);
@@ -316,8 +316,8 @@ class Option
      * # Examples
      *
      * ```php
-     * $x = Hoa\Option\Option::some('Hello, World!');
-     * $y = Hoa\Option\Option::none();
+     * $x = Hoa\Option\Some('Hello, World!');
+     * $y = Hoa\Option\None();
      *
      * $else = function () { return 42; };
      *
@@ -346,9 +346,9 @@ class Option
      * and `$z`:
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
-     * $y = Hoa\Option\Option::some(42);
-     * $z = Hoa\Option\Option::none();
+     * $x = Hoa\Option\Some(42);
+     * $y = Hoa\Option\Some(42);
+     * $z = Hoa\Option\None();
      *
      * assert($x->and($y) === $y);
      * assert($x->and($z) === $z);
@@ -357,8 +357,8 @@ class Option
      * The `$x` option contains no value, so it returns a new option with no value.
      *
      * ```php
-     * $x = Hoa\Option\Option::none();
-     * $y = Hoa\Option\Option::some(42);
+     * $x = Hoa\Option\None();
+     * $y = Hoa\Option\Some(42);
      *
      * assert($x->and($y)->isNone());
      * ```
@@ -381,12 +381,12 @@ class Option
      * # Examples
      *
      * ```php
-     * $x      = Hoa\Option\Option::some(2);
+     * $x      = Hoa\Option\Some(2);
      * $square = function (int $x): Hoa\Option\Option {
-     *     return Hoa\Option\Option::some($x * $x);
+     *     return Hoa\Option\Some($x * $x);
      * };
      * $nop = function(): Hoa\Option\Option {
-     *     return Hoa\Option\Option::none();
+     *     return Hoa\Option\None();
      * };
      *
      * assert($x->andThen($square)->andThen($square)->unwrap() === 16);
@@ -409,9 +409,9 @@ class Option
      * # Examples
      *
      * ```php
-     * $x = Hoa\Option\Option::some(42);
-     * $y = Hoa\Option\Option::some(42);
-     * $z = Hoa\Option\Option::none();
+     * $x = Hoa\Option\Some(42);
+     * $y = Hoa\Option\Some(42);
+     * $z = Hoa\Option\None();
      *
      * assert($x->or($y) === $x);
      * assert($z->or($y) === $y);
@@ -433,13 +433,13 @@ class Option
      * # Examples
      *
      * ```php
-     * $x      = Hoa\Option\Option::none();
-     * $y      = Hoa\Option\Option::some('me');
+     * $x      = Hoa\Option\None();
+     * $y      = Hoa\Option\Some('me');
      * $nobody = function (): Hoa\Option\Option {
-     *     return Hoa\Option\Option::none();
+     *     return Hoa\Option\None();
      * };
      * $somebody = function(): Hoa\Option\Option {
-     *     return Hoa\Option\Option::some('somebody');
+     *     return Hoa\Option\Some('somebody');
      * };
      *
      * assert($x->orElse($somebody)->unwrap() === 'somebody');
@@ -455,26 +455,6 @@ class Option
 
         return $this;
     }
-}
-
-/**
- * Allocate an option representing no value.
- *
- * See `Option::some`.
- */
-function Some($value): Option
-{
-    return Option::some($value);
-}
-
-/**
- * Allocate an option representing no value.
- *
- * See `Option::none`.
- */
-function None(): Option
-{
-    return Option::none();
 }
 
 /**

--- a/Prelude.php
+++ b/Prelude.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2017, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Option;
+
+/**
+ * Allocate an option representing no value.
+ *
+ * See `Hoa\Option\Option::some`.
+ */
+function Some($value): Option
+{
+    return Option::some($value);
+}
+
+/**
+ * Allocate an option representing no value.
+ *
+ * See `Hoa\Option\Option::none`.
+ */
+function None(): Option
+{
+    return Option::none();
+}

--- a/Prelude.php
+++ b/Prelude.php
@@ -37,7 +37,7 @@
 namespace Hoa\Option;
 
 /**
- * Allocate an option representing no value.
+ * Allocate an option with some value.
  *
  * See `Hoa\Option\Option::some`.
  */
@@ -47,7 +47,7 @@ function Some($value): Option
 }
 
 /**
- * Allocate an option representing no value.
+ * Allocate an option with no value.
  *
  * See `Hoa\Option\Option::none`.
  */

--- a/Test/Unit/Option.php
+++ b/Test/Unit/Option.php
@@ -43,7 +43,7 @@ use Hoa\Test;
 use RuntimeException;
 
 /**
- * Class \Hoa\Option\Test\Unit\Console.
+ * Class \Hoa\Option\Test\Unit\Option.
  *
  * Test suite of the option class.
  *
@@ -81,7 +81,7 @@ class Option extends Test\Unit\Suite
     public function case_some()
     {
         $this
-            ->when($result = SUT::some(42))
+            ->when($result = Some(42))
             ->then
                 ->boolean($result->isSome())
                     ->isTrue()
@@ -92,7 +92,7 @@ class Option extends Test\Unit\Suite
     public function case_none()
     {
         $this
-            ->when($result = SUT::none())
+            ->when($result = None())
             ->then
                 ->boolean($result->isNone())
                     ->isTrue()
@@ -103,7 +103,7 @@ class Option extends Test\Unit\Suite
     public function case_some_is_some()
     {
         $this
-            ->given($option = SUT::some(42))
+            ->given($option = Some(42))
             ->when($result = $option->isSome())
             ->then
                 ->boolean($result)
@@ -113,7 +113,7 @@ class Option extends Test\Unit\Suite
     public function case_none_is_some()
     {
         $this
-            ->given($option = SUT::none())
+            ->given($option = None())
             ->when($result = $option->isSome())
             ->then
                 ->boolean($result)
@@ -123,7 +123,7 @@ class Option extends Test\Unit\Suite
     public function case_some_is_none()
     {
         $this
-            ->given($option = SUT::some(42))
+            ->given($option = Some(42))
             ->when($result = $option->isNone())
             ->then
                 ->boolean($result)
@@ -133,7 +133,7 @@ class Option extends Test\Unit\Suite
     public function case_none_is_none()
     {
         $this
-            ->given($option = SUT::none())
+            ->given($option = None())
             ->when($result = $option->isNone())
             ->then
                 ->boolean($result)
@@ -143,7 +143,7 @@ class Option extends Test\Unit\Suite
     public function case_some_expect()
     {
         $this
-            ->given($option = SUT::some(42))
+            ->given($option = Some(42))
             ->when($result = $option->expect('foo'))
             ->then
                 ->integer($result)
@@ -153,7 +153,7 @@ class Option extends Test\Unit\Suite
     public function case_none_expect()
     {
         $this
-            ->given($option = SUT::none())
+            ->given($option = None())
             ->exception(function () use ($option) {
                 $option->expect('foo');
             })
@@ -164,7 +164,7 @@ class Option extends Test\Unit\Suite
     public function case_some_unwrap()
     {
         $this
-            ->given($option = SUT::some(42))
+            ->given($option = Some(42))
             ->when($result = $option->unwrap())
             ->then
                 ->integer($result)
@@ -174,7 +174,7 @@ class Option extends Test\Unit\Suite
     public function case_none_unwrap()
     {
         $this
-            ->given($option = SUT::none())
+            ->given($option = None())
             ->exception(function () use ($option) {
                 $option->unwrap();
             })
@@ -185,7 +185,7 @@ class Option extends Test\Unit\Suite
     public function case_some_unwrap_or()
     {
         $this
-            ->given($option = SUT::some(42))
+            ->given($option = Some(42))
             ->when($result = $option->unwrapOr(153))
             ->then
                 ->integer($result)
@@ -195,7 +195,7 @@ class Option extends Test\Unit\Suite
     public function case_none_unwrap_or()
     {
         $this
-            ->given($option = SUT::none())
+            ->given($option = None())
             ->when($result = $option->unwrapOr(153))
             ->then
                 ->integer($result)
@@ -206,7 +206,7 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::some(42),
+                $option = Some(42),
                 $else   = function (): int {
                     return 153;
                 }
@@ -221,7 +221,7 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::none(),
+                $option = None(),
                 $else   = function (): int {
                     return 153;
                 }
@@ -236,7 +236,7 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::some(42),
+                $option = Some(42),
                 $mapper = function (int $x): int {
                     return $x * 2;
                 }
@@ -253,7 +253,7 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::none(),
+                $option = None(),
                 $mapper = function (int $x): int {
                     return $x * 2;
                 }
@@ -270,7 +270,7 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::some(42),
+                $option = Some(42),
                 $mapper = function (int $x): int {
                     return $x * 2;
                 }
@@ -287,7 +287,7 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::none(),
+                $option = None(),
                 $mapper = function (int $x): int {
                     return $x * 2;
                 }
@@ -304,7 +304,7 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::some(42),
+                $option = Some(42),
                 $else   = function (): int {
                     return 153;
                 },
@@ -324,7 +324,7 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::none(),
+                $option = None(),
                 $else   = function (): int {
                     return 153;
                 },
@@ -344,8 +344,8 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option      = SUT::some(42),
-                $rightOption = SUT::some(153)
+                $option      = Some(42),
+                $rightOption = Some(153)
             )
             ->when($result = $option->and($rightOption))
             ->then
@@ -357,8 +357,8 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option      = SUT::some(42),
-                $rightOption = SUT::none()
+                $option      = Some(42),
+                $rightOption = None()
             )
             ->when($result = $option->and($rightOption))
             ->then
@@ -370,8 +370,8 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option      = SUT::none(),
-                $rightOption = SUT::some(153)
+                $option      = None(),
+                $rightOption = Some(153)
             )
             ->when($result = $option->and($rightOption))
             ->then
@@ -384,8 +384,8 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option      = SUT::none(),
-                $rightOption = SUT::none()
+                $option      = None(),
+                $rightOption = None()
             )
             ->when($result = $option->and($rightOption))
             ->then
@@ -398,45 +398,45 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::some(42),
+                $option = Some(42),
                 $mapper = function (): SUT {
-                    return SUT::some(153);
+                    return Some(153);
                 }
             )
             ->when($result = $option->andThen($mapper))
             ->then
                 ->object($result)
-                    ->isEqualTo(SUT::some(153));
+                    ->isEqualTo(Some(153));
     }
 
     public function case_some_and_then_none()
     {
         $this
             ->given(
-                $option = SUT::some(42),
+                $option = Some(42),
                 $mapper = function (): SUT {
-                    return SUT::none();
+                    return None();
                 }
             )
             ->when($result = $option->andThen($mapper))
             ->then
                 ->object($result)
-                    ->isEqualTo(SUT::none());
+                    ->isEqualTo(None());
     }
 
     public function case_none_and_then_some()
     {
         $this
             ->given(
-                $option = SUT::none(),
+                $option = None(),
                 $mapper = function (): SUT {
-                    return SUT::some(153);
+                    return Some(153);
                 }
             )
             ->when($result = $option->andThen($mapper))
             ->then
                 ->object($result)
-                    ->isEqualTo(SUT::none())
+                    ->isEqualTo(None())
                     ->isNotIdenticalTo($option);
     }
 
@@ -444,15 +444,15 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::none(),
+                $option = None(),
                 $mapper = function (): SUT {
-                    return SUT::some(153);
+                    return Some(153);
                 }
             )
             ->when($result = $option->andThen($mapper))
             ->then
                 ->object($result)
-                    ->isEqualTo(SUT::none())
+                    ->isEqualTo(None())
                     ->isNotIdenticalTo($option);
     }
 
@@ -460,8 +460,8 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option      = SUT::some(42),
-                $rightOption = SUT::some(153)
+                $option      = Some(42),
+                $rightOption = Some(153)
             )
             ->when($result = $option->or($rightOption))
             ->then
@@ -473,8 +473,8 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option      = SUT::some(42),
-                $rightOption = SUT::none()
+                $option      = Some(42),
+                $rightOption = None()
             )
             ->when($result = $option->or($rightOption))
             ->then
@@ -486,8 +486,8 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option      = SUT::none(),
-                $rightOption = SUT::some(153)
+                $option      = None(),
+                $rightOption = Some(153)
             )
             ->when($result = $option->or($rightOption))
             ->then
@@ -499,8 +499,8 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option      = SUT::none(),
-                $rightOption = SUT::none()
+                $option      = None(),
+                $rightOption = None()
             )
             ->when($result = $option->or($rightOption))
             ->then
@@ -512,9 +512,9 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::some(42),
+                $option = Some(42),
                 $else   = function (): SUT {
-                    return SUT::some(153);
+                    return Some(153);
                 }
             )
             ->when($result = $option->orElse($else))
@@ -527,9 +527,9 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::some(42),
+                $option = Some(42),
                 $else   = function (): SUT {
-                    return SUT::none();
+                    return None();
                 }
             )
             ->when($result = $option->orElse($else))
@@ -542,29 +542,29 @@ class Option extends Test\Unit\Suite
     {
         $this
             ->given(
-                $option = SUT::none(),
+                $option = None(),
                 $else   = function (): SUT {
-                    return SUT::some(153);
+                    return Some(153);
                 }
             )
             ->when($result = $option->orElse($else))
             ->then
                 ->object($result)
-                    ->isEqualTo(SUT::some(153));
+                    ->isEqualTo(Some(153));
     }
 
     public function case_none_or_then_none()
     {
         $this
             ->given(
-                $option = SUT::none(),
+                $option = None(),
                 $else   = function (): SUT {
-                    return SUT::some(153);
+                    return Some(153);
                 }
             )
             ->when($result = $option->orElse($else))
             ->then
                 ->object($result)
-                    ->isEqualTo(SUT::some(153));
+                    ->isEqualTo(Some(153));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "autoload": {
         "psr-4": {
             "Hoa\\Option\\": "."
-        }
+        },
+        "files": ["Prelude.php"]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
The prelude is autoloaded by Composer, so that `Hoa\Option\Some` and
`Hoa\Option\None` are always loaded. It is possible to write this:

```
use function Hoa\Option\{Some, None};

$x = Some(42);
$y = None();
```