### PR TITLE
feat(option) Update the `unwrap` default message.

### DIFF
--- a/Option.php
+++ b/Option.php
@@ -211,7 +211,7 @@ final class Option
      */
     public function unwrap()
     {
-        return $this->expect('Unwrap a null value.');
+        return $this->expect('Called `' . __METHOD__ . '` on a none value.');
     }
 
     /**

--- a/Test/Unit/Option.php
+++ b/Test/Unit/Option.php
@@ -178,8 +178,8 @@ class Option extends Test\Unit\Suite
             ->exception(function () use ($option) {
                 $option->unwrap();
             })
-            ->isInstanceOf(RuntimeException::class)
-                ->hasMessage('Unwrap a null value.');
+                ->isInstanceOf(RuntimeException::class)
+                ->hasMessage('Called `' . SUT::class . '::unwrap` on a none value.');
     }
 
     public function case_some_unwrap_or()


### PR DESCRIPTION
As @mathroc suggested in https://github.com/hoaproject/Option/issues/10, the panic message should not reflect an implementation detail but must reflect the semantics of the operation.

Fix #10.