### PR TITLE
feat(option) Cannot call `Some` with `null`.

### DIFF
--- a/Option.php
+++ b/Option.php
@@ -37,6 +37,7 @@
 namespace Hoa\Option;
 
 use Hoa\Consistency;
+use RuntimeException;
 
 /**
  * Class \Hoa\Option.
@@ -88,6 +89,13 @@ final class Option
      */
     public static function some($value): self
     {
+        if (null === $value) {
+            throw new RuntimeException(
+                'Called `' . __METHOD__ . '` with a `null` value, forbidden. ' .
+                'Use `' . __CLASS__ . '::none` instead.'
+            );
+        }
+
         return new self($value);
     }
 
@@ -174,7 +182,7 @@ final class Option
     public function expect(string $errorMessage)
     {
         if (true === $this->isNone()) {
-            throw new \RuntimeException($errorMessage);
+            throw new RuntimeException($errorMessage);
         }
 
         return $this->_value;

--- a/Test/Unit/Option.php
+++ b/Test/Unit/Option.php
@@ -89,6 +89,19 @@ class Option extends Test\Unit\Suite
                     ->isEqualTo(42);
     }
 
+    public function case_some_null()
+    {
+        $this
+            ->exception(function () {
+                Some(null);
+            })
+                ->isInstanceOf(RuntimeException::class)
+                ->hasMessage(
+                    'Called `' . SUT::class . '::some` with a `null` value, forbidden. ' .
+                    'Use `' . SUT::class . '::none` instead.'
+                );
+    }
+
     public function case_none()
     {
         $this


### PR DESCRIPTION
It must be forbidden to call `Some(null)`. Of course, `Some(null)->isSome()` is false, but it does not respect the semantics of the option.

Fix #9.